### PR TITLE
fix (pip) install when Cython isn't already present.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup, Extension, find_packages
 requirements = [
     'numpy',
     'scipy',
-    'Cython',
 ]
 
 


### PR DESCRIPTION
Remove Cython from install_requires as it is really just a build_requires, and setup.py errored out on the Cython import anyway without Cython already present.

See https://github.com/pypa/pip/issues/6193 for further references.